### PR TITLE
Add status indicator

### DIFF
--- a/toggle_dnd
+++ b/toggle_dnd
@@ -2,7 +2,9 @@
 value=$(gsettings get org.gnome.desktop.notifications show-banners)
 if [[ $value == 'true' ]]
 then
+  notify-send "Notifications are disabled" -i user-busy
   gsettings set org.gnome.desktop.notifications show-banners false
 else
   gsettings set org.gnome.desktop.notifications show-banners true
+  notify-send "Notifications are enabled" -i user-available
 fi


### PR DESCRIPTION
There's no way to know whether DND is enabled or disabled.

This change would show an alert to indicate what the status is.

Note: there is a feature/bug in libnotify that prevents the timeout flag from working on Ubuntu, so the timeout of this alert can't be customized https://askubuntu.com/questions/110969/notify-send-ignores-timeout